### PR TITLE
Fresh box

### DIFF
--- a/src/00-utils/symbol.ml
+++ b/src/00-utils/symbol.ml
@@ -5,6 +5,7 @@ module type S = sig
   val fresh : string -> t
   val refresh : t -> t
   val print : t -> Format.formatter -> unit
+  val string_of : t -> string
 end
 
 module Make () : S = struct
@@ -19,4 +20,5 @@ module Make () : S = struct
 
   let refresh (_, ann) = fresh ann
   let print (_n, ann) ppf = Format.fprintf ppf "%s" ann
+  let string_of (_, ann) = ann
 end

--- a/src/05-backends/interpreter/core/interpreter.ml
+++ b/src/05-backends/interpreter/core/interpreter.ml
@@ -269,11 +269,16 @@ let rec step_computation env = function
       let rec doBox tau expr pat comp =
         match pat with
         | Ast.PVar x ->
+            let x' = Ast.Variable.fresh "box_var" in
             let state' =
-              ContextHolderModule.add_variable x (tau, expr) env.state
+              ContextHolderModule.add_variable x' (tau, expr) env.state
             in
             let env' = { env with state = state' } in
-            [ (env', ComputationRedex Box, fun () -> comp) ]
+            [
+              ( env',
+                ComputationRedex Box,
+                fun () -> refresh_computation [ (x, x') ] comp );
+            ]
         | Ast.PAnnotated (pat', _) -> doBox tau expr pat' comp
         | _ ->
             Error.runtime "Box expected a variable but got pattern %t"

--- a/src/05-backends/interpreter/core/interpreter.ml
+++ b/src/05-backends/interpreter/core/interpreter.ml
@@ -269,7 +269,7 @@ let rec step_computation env = function
       let rec doBox tau expr pat comp =
         match pat with
         | Ast.PVar x ->
-            let x' = Ast.Variable.fresh "box_var" in
+            let x' = Ast.Variable.fresh (Ast.Variable.string_of x) in
             let state' =
               ContextHolderModule.add_variable x' (tau, expr) env.state
             in

--- a/src/05-backends/sig/core/backend.ml
+++ b/src/05-backends/sig/core/backend.ml
@@ -14,6 +14,7 @@ module type S = sig
     variables : Tau.t Ast.expression ContextHolderModule.t;
     builtin_functions :
       (Tau.t Ast.expression -> Tau.t Ast.computation) ContextHolderModule.t;
+    resource_counter : int;
   }
 
   val initial_load_state : load_state


### PR DESCRIPTION
The `box` operation did not previously use fresh names when adding resources to the state. This resulted in the exact same variable (name and identifier) being used when boxing happened in a function closure that was called multiple times.

Therefore previously the 3D-printing example

```
type model = Model of string
type fresh = Fresh of model
type cooled = Cooled of fresh
type uvCured = UvCured of cooled
type complete = Complete of uvCured

(* Mock 3D printing operation with signature model -> [5]fresh # 7 *)
let printResinModel model = delay 7 box 5 (Fresh model) as
            printingResult in printingResult

(* Mock UV curing operation with signature cooled -> uvCured # 10 *)
let uvCure cooledObject = delay 5 (UvCured cooledObject)

run
    let freshSword = printResinModel (Model "Sword") in
    let freshHammer = printResinModel (Model "Hammer") in
    unbox 5 freshSword as cooledSword in 
    let curedSword = uvCure (Cooled cooledSword) in
    unbox 5 freshHammer as cooledHammer in
    let curedHammer = uvCure (Cooled cooledHammer) in
    (Complete curedSword, Complete curedHammer)
```

resulted in 

```
return (Complete (UvCured (Cooled (Fresh (Model "Hammer")))), 
        Complete (UvCured (Cooled (Fresh (Model "Hammer")))))
```

because the two calls to `printResinModel` resulted in the resource being attached to the exact same `printingResult` variable in the state (both in terms of its name and underlying idenfifier).

With this PR, the `box` operation always creates a fresh variable, and the 3D-printing example now returns

```
return (Complete (UvCured (Cooled (Fresh (Model "Sword")))), 
        Complete (UvCured (Cooled (Fresh (Model "Hammer")))))
```

as desired.

~Currently the human-readable name of the freshly created variable is kept the same as the original one.~

The resources added to the state are given unique names.